### PR TITLE
normalize_variant now works when chrom is zero and idx[1] is zero, pr…

### DIFF
--- a/c/src/genoref.c
+++ b/c/src/genoref.c
@@ -46,7 +46,7 @@ inline char get_genoref_seq(const unsigned char *src, const uint32_t idx[], uint
 inline int check_reference(const unsigned char *src, const uint32_t idx[], uint8_t chrom, uint32_t pos, const char *ref, size_t sizeref)
 {
     uint32_t offset = (idx[chrom] + pos);
-    if ((offset + sizeref - 1) > (idx[(chrom + 1)] - 2))
+    if ((offset + sizeref + 1) > (idx[(chrom + 1)]))
     {
         return -2; // invalid position
     }
@@ -151,7 +151,7 @@ inline void flip_allele(char *allele, size_t size)
     allele[size] = 0;
 }
 
-inline int normalize_variant(const unsigned char *src, const uint32_t idx[], uint8_t chrom, uint32_t *pos, char *ref, size_t *sizeref, char *alt, size_t *sizealt)
+int normalize_variant(const unsigned char *src, const uint32_t idx[], uint8_t chrom, uint32_t *pos, char *ref, size_t *sizeref, char *alt, size_t *sizealt)
 {
     char left;
     char fref[ALLELE_MAXSIZE];


### PR DESCRIPTION
…eviously idx[(chrom + 1)] - 2 would overflow. also removed inline keyword which would mean it is not exported.